### PR TITLE
Escape JSON Pointer strings

### DIFF
--- a/src/JSONPointer/Model.hs
+++ b/src/JSONPointer/Model.hs
@@ -4,6 +4,7 @@ module JSONPointer.Model
   , atIndexOrKey
   , atKey
   , escapeKey
+  , unescapeKey
   )
 where
 
@@ -60,3 +61,9 @@ atKey = atIndexOrKey Nothing
 -- See here https://datatracker.ietf.org/doc/html/rfc6901 for more details.
 escapeKey :: T.Text -> T.Text
 escapeKey = T.replace "/" "~1" . T.replace "~" "~0"
+
+-- |
+-- Unscape JSON Pointer string.
+-- See here https://datatracker.ietf.org/doc/html/rfc6901 for more details.
+unescapeKey :: T.Text -> T.Text
+unescapeKey = T.replace "~0" "~" . T.replace "~1" "/"

--- a/src/JSONPointer/Model.hs
+++ b/src/JSONPointer/Model.hs
@@ -3,6 +3,7 @@ module JSONPointer.Model
   , run
   , atIndexOrKey
   , atKey
+  , escapeKey
   )
 where
 
@@ -26,7 +27,7 @@ instance Monoid JSONPointer where
 
 instance Show JSONPointer where
   showsPrec _ (JSONPointer impl) =
-    appEndo $ impl (\_ text -> Endo (showString "/" . showString (T.unpack text)))
+    appEndo $ impl (\_ text -> Endo (showString "/" . showString (T.unpack $ escapeKey text)))
 
 instance Eq JSONPointer where
   a == b = show a == show b
@@ -53,3 +54,9 @@ atIndexOrKey index key = JSONPointer $ \handler -> handler index key
 {-# INLINE atKey #-}
 atKey :: T.Text -> JSONPointer
 atKey = atIndexOrKey Nothing
+
+-- |
+-- Escape JSON Pointer string.
+-- See here https://datatracker.ietf.org/doc/html/rfc6901 for more details.
+escapeKey :: T.Text -> T.Text
+escapeKey = T.replace "/" "~1" . T.replace "~" "~0"


### PR DESCRIPTION
This PR proposes to:
- Escape JSON pointer strings before rendering/serialising them.
- Add and export two utility functions for escaping and unescaping JSON pointer strings.